### PR TITLE
List command fails with error when a project has never been built

### DIFF
--- a/src/circle-ci.coffee
+++ b/src/circle-ci.coffee
@@ -64,8 +64,8 @@ getProjectsByStatus = (msg, endpoint, status, action) ->
       .get() handleResponse msg, (response) ->
         for project in response
           build_branch = project.branches[project.default_branch]
-          last_build = build_branch.recent_builds[0]
-          if last_build.outcome is status
+          last_build = build_branch.recent_builds?[0]
+          if last_build?.outcome is status
             projects.push project
         if action is 'list'
           listProjectsByStatus(msg, projects, status)


### PR DESCRIPTION
To repro:
1. Add a project to CircleCI that has no circle config
2. Run `hubot circle list <failed>/<success>`

The bot will output nothing, and the following appears in the logs:

``` js
[Wed Oct 21 2015 18:25:45 GMT+0000 (UTC)] ERROR TypeError: Cannot read property '0' of undefined
  at /app/node_modules/hubot-circleci/src/circle-ci.coffee:67:51, <js>:52:48
  at /app/node_modules/hubot-circleci/src/circle-ci.coffee:129:9, <js>:142:18
  at IncomingMessage.emit (events.js:117:20)
  at IncomingMessage.<anonymous> (/app/node_modules/hubot/node_modules/scoped-http-client/src/index.js:95:22)
  at _stream_readable.js:944:16


  at process._tickCallback (node.js:448:13)
```

This fix allows for null results for the default branch.
