### PR TITLE
More descriptive msg upon 500 response status

### DIFF
--- a/src/circle-ci.coffee
+++ b/src/circle-ci.coffee
@@ -123,7 +123,7 @@ handleResponse = (msg, handler) ->
       when 401
         msg.send 'Not authorized.  Did you set HUBOT_CIRCLECI_TOKEN correctly?'
       when 500
-        msg.send 'Yikes!  I turned that circle into a square' # Don't send body since we'll get HTML back from Circle
+        msg.send 'Yikes!  I turned that circle into a square (CircleCI responded 500)' # Don't send body since we'll get HTML back from Circle
       when 200
         response = JSON.parse(body)
         handler response


### PR DESCRIPTION
The current message from Hubot when it receives a 500 status from CircleCI doesn't really make it clear what happened.  Added parenthetical to make it clear what happened.
